### PR TITLE
Add a shebang and a minor refactor

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,7 +1,8 @@
+#!/usr/bin/env python3
+
 import os
 from shutil import which
 from subprocess import Popen, PIPE
-from sys import version_info
 
 enable_swagger = '{{cookiecutter.enable_swagger}}' == 'y'
 
@@ -11,7 +12,7 @@ def cleanup_requirements_file(file_name, items_to_remove):
         data = fh.read()
     os.remove(file_name)
     data = data.split("\n")
-    data = [d for d in data if not d in items_to_remove]
+    data = [d for d in data if d not in items_to_remove]
     with open(file_name, "w") as fh:
         fh.write("\n".join(data))
 


### PR DESCRIPTION
3 Changes:

1. Add a shebang because I get the following error while scaffolding:
```
Traceback (most recent call last):
  File "/tmp/tmpEn2PdS.py", line 2, in <module>
    from shutil import which
ImportError: cannot import name which
ERROR: Stopping generation because post_gen_project hook script didn't exit successfully
Hook script failed (exit status: 1)
```
2. removed unused version_info
3. `if item not in items` is more pythonic usage.